### PR TITLE
📝 Linked the store buttons to the link of the extension page on web

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,12 @@
      <h3>VE Checklist</h3>
     <h4>Checklist Tool for OpenText ValueEdge platform.</h4>
     <div align="center">
-        <img  src="https://img.shields.io/badge/Google_chrome-4285F4?style=for-the-badge&logo=Google-chrome&logoColor=white">
-        <img  src="https://img.shields.io/badge/Microsoft_Edge-0078D7?style=for-the-badge&logo=Microsoft-edge&logoColor=white">
+        <a href="https://chromewebstore.google.com/detail/ve-checklist/aeiiagpokicaeifancpnndjanamdmmdn/reviews">
+          <img  src="https://img.shields.io/badge/Google_chrome-4285F4?style=for-the-badge&logo=Google-chrome&logoColor=white">
+        </a>
+        <a href="https://chromewebstore.google.com/detail/ve-checklist/aeiiagpokicaeifancpnndjanamdmmdn/reviews">
+          <img  src="https://img.shields.io/badge/Microsoft_Edge-0078D7?style=for-the-badge&logo=Microsoft-edge&logoColor=white">
+        </a>
     </div>
 </div>
 
@@ -20,7 +24,8 @@
 * Open a ValueEdge ticket in your browser.
 * Right-click anywhere on the page.
 * In the context menu, you will see an option called **VE Checklist**.
-* Click on it to open a pop-up displaying the Done Checklist for the ticket.
+* Click on it to open a pop-up displaying the Done Checklist for the ticket.
+
 
 #### Example Checklist
 


### PR DESCRIPTION
This PR fixes the links on the README to take to the chrome extension store from where users can download the extension